### PR TITLE
Fix an issue where mixed side effects/declaration inside if statements are not detected

### DIFF
--- a/src/Analyzer/Psr1Analyzer.php
+++ b/src/Analyzer/Psr1Analyzer.php
@@ -63,10 +63,8 @@ readonly class Psr1Analyzer
                 $declarations[] = $nodeName;
             } elseif ($stmt instanceof Stmt\If_) {
                 [$insideDeclarations, $insideSideEffects] = $this->parseSideEffects($stmt->stmts);
-
-                if (count($insideSideEffects) === 0) {
-                    $declarations = array_merge($declarations, $insideDeclarations);
-                }
+                $declarations = array_merge($declarations, $insideDeclarations);
+                $sideEffects = array_merge($sideEffects, $insideSideEffects);
             } else {
                 $sideEffects[] = $nodeName;
             }

--- a/tests/Analyzer/data/mixed-sideeffects/if.php
+++ b/tests/Analyzer/data/mixed-sideeffects/if.php
@@ -1,0 +1,9 @@
+<?php
+
+function foo(): void
+{
+}
+
+if (rand(1, 2) === 1) {
+    echo 'foo';
+}

--- a/tests/Analyzer/data/mixed-sideeffects/mixed-inside-if.php
+++ b/tests/Analyzer/data/mixed-sideeffects/mixed-inside-if.php
@@ -1,0 +1,9 @@
+<?php
+
+if (rand(1, 2) === 1) {
+    function bar(): void
+    {
+    }
+
+    echo 'foo';
+}


### PR DESCRIPTION
# Problem

The following 2 files are expected to be detected as "MIXED_SIDE_EFFECTS", but actually are not.

```php
<?php

function foo(): void
{
}

if (rand(1, 2) === 1) {
    echo 'foo';
}
```

```php
<?php

if (rand(1, 2) === 1) {
    function bar(): void
    {
    }

    echo 'foo';
}
```

# Solution

Propagate the found side effects and declarations inside if statements to outer analysis.